### PR TITLE
Update the handleReturn to conform to the 2.0.X breaking API change

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,7 +24,7 @@ var defaultOptions = {
  * @return {Object} Compatible draft-js-editor-plugin object
  */
 function singleLinePlugin() {
-  var options = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+  var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
 
   options = Object.assign({}, defaultOptions, options);
 
@@ -104,7 +104,7 @@ function singleLinePlugin() {
      * @return {Boolean} Did we handle the return or not? (pro-trip: yes, we did)
      */
     handleReturn: function handleReturn(e) {
-      return true;
+      return 'handled';
     }
   };
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -26,7 +26,7 @@ var NEWLINE_REGEX = exports.NEWLINE_REGEX = /\n/g;
  * @return {String} Modified string
  */
 function replaceNewlines(str) {
-  var replacement = arguments.length <= 1 || arguments[1] === undefined ? ' ' : arguments[1];
+  var replacement = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : ' ';
 
   return str.replace(NEWLINE_REGEX, replacement);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -102,10 +102,10 @@ function singleLinePlugin (options = {}) {
      * Stop new lines being inserted by always handling the return
      *
      * @param  {KeyboardEvent} e Synthetic keyboard event from draftjs
-     * @return {Boolean} Did we handle the return or not? (pro-trip: yes, we did)
+     * @return {string} Did we handle the return or not? (pro-trip: yes, we did)
      */
     handleReturn (e) {
-      return true
+      return `handled`
     },
   }
 }


### PR DESCRIPTION
See this commit: https://github.com/draft-js-plugins/draft-js-plugins/commit/fdc158ef606b5257539d6d661cad4bee328aa977

The handler for `onReturn` needs to return `handled` now, not `true`