### PR TITLE
Don't create new state when stripEntities is false

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -63,8 +63,9 @@ function singleLinePlugin() {
         var contentBlock = blocks[0];
         var text = contentBlock.getText();
         var characterList = contentBlock.getCharacterList();
+        var hasEntitiesToStrip = options.stripEntities && (0, _utils.characterListhasEntities)(characterList);
 
-        if (_utils.NEWLINE_REGEX.test(text) || (0, _utils.characterListhasEntities)(characterList)) {
+        if (_utils.NEWLINE_REGEX.test(text) || hasEntitiesToStrip) {
           // Replace the text stripped of its newlines. Note that we replace
           // one '\n' with one ' ' so we don't need to modify the characterList
           text = (0, _utils.replaceNewlines)(text);
@@ -89,7 +90,6 @@ function singleLinePlugin() {
 
           // Create the new state as an undoable action
           editorState = _draftJs.EditorState.push(editorState, newContentState, 'insert-characters');
-          editorState = _draftJs.EditorState.moveFocusToEnd(editorState);
         }
       }
 

--- a/src/index.js
+++ b/src/index.js
@@ -65,8 +65,9 @@ function singleLinePlugin (options = {}) {
         let contentBlock = blocks[0]
         let text = contentBlock.getText()
         let characterList = contentBlock.getCharacterList()
+        let hasEntitiesToStrip = options.stripEntities && characterListhasEntities(characterList)
 
-        if (NEWLINE_REGEX.test(text) || characterListhasEntities(characterList)) {
+        if (NEWLINE_REGEX.test(text) || hasEntitiesToStrip) {
           // Replace the text stripped of its newlines. Note that we replace
           // one '\n' with one ' ' so we don't need to modify the characterList
           text = replaceNewlines(text)
@@ -91,7 +92,6 @@ function singleLinePlugin (options = {}) {
 
           // Create the new state as an undoable action
           editorState = EditorState.push(editorState, newContentState, 'insert-characters')
-          editorState = EditorState.moveFocusToEnd(editorState)
         }
       }
 


### PR DESCRIPTION
If stripEntities is false then there is no reason to try to strip new lines. Also prevents moving cursor to the end of the line after any change.