### PR TITLE
Upgrade immutable to ~3.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "tape": "4.5.1"
   },
   "dependencies": {
-    "immutable": "~3.7.4"
+    "immutable": "~3.8.2"
   }
 }


### PR DESCRIPTION
This tracks the most recent stable version of immutable.

As far as I can tell, there are no backwards incompatible changes.

Let me know if there is anything I can do to help you review or merge this.