### PR TITLE
Give a more flexible range to immutable dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
     "tape": "4.5.1"
   },
   "dependencies": {
-    "immutable": "~3.8.2"
+    "immutable": "^3.7.4"
   }
 }


### PR DESCRIPTION
As noted [in this issue](https://github.com/icelab/draft-js-single-line-plugin/pull/5#issuecomment-513932847), the range for usage in draft-js is pinned to 3.7.x but we want to allow people to use it more flexibly if they care to.