### PR TITLE
Stick with draft-js compatible immutable.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
     "tape": "4.5.1"
   },
   "dependencies": {
-    "immutable": "^3.7.4"
+    "immutable": "~3.7.4"
   }
 }


### PR DESCRIPTION
User cannot control installing transitive dependencies. Caret range will install the latest minor version which is not what draft-js expects. Alternative solution would be moving immutable.js to peerDependencies.